### PR TITLE
add media hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /venv
 /*.json
 /*.log
+media_hash.pickle


### PR DESCRIPTION
Solución muy temporal hasta que tengamos una base de datos

1. Guardamos los ids del media como un set
2. Para persistencia guardamos el set como un archivo pickle
3. Dentro de la función save_in_telegram está la lógica. El único pero es que cuando está repetido el medio, imprime un mensaje de error pq la función save_in_telegram devuelve None pero aparte de eso funciona como uno esperaría